### PR TITLE
Rename CommonTypes to Types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,10 @@
+# Ignore build outputs
+bin/
+obj/
+**/bin/
+**/obj/
+# user-specific files
+*.user
+*.suo
+# Visual Studio Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -20,3 +20,7 @@ Each project is self-contained and can be deployed independently.
 ```
 
 `/projects` holds separately deployable domains. Shared libraries or utilities should reside under `/shared`.
+
+Each project has its own *.sln solution within its folder, including shared libraries.
+
+For common types used across projects, see `shared/Types`.

--- a/shared/README.md
+++ b/shared/README.md
@@ -1,3 +1,9 @@
 # Shared Libraries
 
 Common utilities and shared code used across multiple projects.
+
+## Types library
+
+`Types` is a .NET class library targeting **net9.0**. It currently provides
+a simple `Result` record that projects can use to represent success or failure
+outcomes.

--- a/shared/Types/Result.cs
+++ b/shared/Types/Result.cs
@@ -1,0 +1,8 @@
+namespace Types
+{
+    public record Result(bool IsSuccess, string? ErrorMessage)
+    {
+        public static Result Success() => new(true, null);
+        public static Result Failure(string message) => new(false, message);
+    }
+}

--- a/shared/Types/Types.csproj
+++ b/shared/Types/Types.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <Nullable>enable</Nullable>
+    <LangVersion>latest</LangVersion>
+  </PropertyGroup>
+
+</Project>

--- a/shared/Types/Types.sln
+++ b/shared/Types/Types.sln
@@ -1,0 +1,34 @@
+﻿
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31903.59
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types", "Types.csproj", "{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Debug|x64 = Debug|x64
+		Debug|x86 = Debug|x86
+		Release|Any CPU = Release|Any CPU
+		Release|x64 = Release|x64
+		Release|x86 = Release|x86
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|x64.Build.0 = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Debug|x86.Build.0 = Debug|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|Any CPU.Build.0 = Release|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x64.ActiveCfg = Release|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x64.Build.0 = Release|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x86.ActiveCfg = Release|Any CPU
+		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x86.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- rename `CommonTypes` library to `Types`
- create `Types.sln` for the shared library and remove old root solution
- update READMEs with per-project solution guidance

## Testing
- `dotnet build shared/Types/Types.sln -c Release`


------
https://chatgpt.com/codex/tasks/task_e_6865ca5a07488324865a6287b077d036