### PR TITLE
Add Docker setup for PostgreSQL

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,6 +16,9 @@ Each project is self-contained and can be deployed independently.
       /deploy
     /project-b
       ...
+    /PostgreSql
+      /migrations
+      /scripts
   /shared
 ```
 
@@ -24,3 +27,9 @@ Each project is self-contained and can be deployed independently.
 Each project has its own *.sln solution within its folder, including shared libraries.
 
 For common types used across projects, see `shared/Types`.
+
+The `PostgreSql` project stores database migrations and scripts such as
+`install-postgres.sh` for installing PostgreSQL on Ubuntu.
+A docker-compose file allows running PostgreSQL in a container.
+
+

--- a/projects/PostgreSql/README.md
+++ b/projects/PostgreSql/README.md
@@ -1,0 +1,23 @@
+# PostgreSql Project
+
+This project contains all resources related to the PostgreSQL database used across other services. It holds:
+
+- **migrations** – SQL scripts for initializing and evolving the database schema.
+- **scripts** – helper scripts for installing PostgreSQL, managing users, and performing backups.
+
+The `scripts/install-postgres.sh` script installs PostgreSQL on Ubuntu 24.04 and creates a default admin user. Environment variables `POSTGRES_USER` and `POSTGRES_PASSWORD` can be supplied to customize the credentials.
+
+## Running with Docker
+
+A `docker-compose.yml` file is provided to quickly start PostgreSQL in a container.
+It uses the official `postgres:16` image and mounts the `migrations` directory so
+any SQL files are executed on first startup.
+
+```bash
+# start in detached mode
+POSTGRES_USER=myuser POSTGRES_PASSWORD=secret \
+  docker compose -f docker-compose.yml up -d
+```
+
+The database will be accessible on port 5432 and persisted in the `pgdata` volume.
+

--- a/projects/PostgreSql/docker-compose.yml
+++ b/projects/PostgreSql/docker-compose.yml
@@ -1,0 +1,16 @@
+version: '3.8'
+services:
+  postgres:
+    image: postgres:16
+    restart: unless-stopped
+    environment:
+      POSTGRES_USER: ${POSTGRES_USER:-admin}
+      POSTGRES_PASSWORD: ${POSTGRES_PASSWORD:-admin}
+      POSTGRES_DB: ${POSTGRES_DB:-admin}
+    ports:
+      - "5432:5432"
+    volumes:
+      - pgdata:/var/lib/postgresql/data
+      - ./migrations:/docker-entrypoint-initdb.d:ro
+volumes:
+  pgdata:

--- a/projects/PostgreSql/migrations/README.md
+++ b/projects/PostgreSql/migrations/README.md
@@ -1,0 +1,2 @@
+This directory stores SQL migration files executed when the PostgreSQL container starts.
+Place initialization scripts such as table creation statements here.

--- a/projects/PostgreSql/scripts/install-postgres.sh
+++ b/projects/PostgreSql/scripts/install-postgres.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+set -euo pipefail
+
+# Install PostgreSQL on Ubuntu 24.04 and configure a default admin role.
+# Based on instructions from https://www.postgresql.org/docs/current/
+
+# Update package information
+sudo apt-get update
+
+# Install PostgreSQL packages
+sudo apt-get install -y postgresql postgresql-contrib
+
+# Determine credentials from environment or defaults
+DB_USER="${POSTGRES_USER:-admin}"
+DB_PASSWORD="${POSTGRES_PASSWORD:-admin}"
+
+# Create the role if it does not already exist
+sudo -u postgres psql <<SQL
+DO
+$$
+BEGIN
+   IF NOT EXISTS (SELECT FROM pg_catalog.pg_roles WHERE rolname = '$DB_USER') THEN
+      CREATE ROLE $DB_USER WITH LOGIN PASSWORD '$DB_PASSWORD' CREATEDB;
+   END IF;
+END
+$$;
+SQL
+
+# Create a database owned by the user if it doesn't exist
+sudo -u postgres psql -tAc "SELECT 1 FROM pg_database WHERE datname='$DB_USER'" | grep -q 1 || sudo -u postgres createdb -O "$DB_USER" "$DB_USER"
+
+echo "PostgreSQL installation complete. Default user: $DB_USER"


### PR DESCRIPTION
## Summary
- add docker-compose file for running PostgreSQL in a container
- document Docker usage in PostgreSql README
- mention Docker option in root README
- provide placeholder migrations directory

## Testing
- `bash -n projects/PostgreSql/scripts/install-postgres.sh`
- `shellcheck projects/PostgreSql/scripts/install-postgres.sh` *(fails: command not found)*
- `docker compose version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6865d1043104832489a00666bc5d6eab