### PR TITLE
Add Money currency abstraction

### DIFF
--- a/shared/Types.Test/Money/MoneyTest.cs
+++ b/shared/Types.Test/Money/MoneyTest.cs
@@ -1,0 +1,32 @@
+using Types.Money;
+using MoneyValue = Types.Money.Money;
+
+namespace Types.Test.Money;
+
+public class MoneyTest
+{
+    [Fact]
+    public void Equality_Is_AmountAndCurrencyBased()
+    {
+        var m1 = new MoneyValue(1m, new Usd());
+        var m2 = new MoneyValue(1m, new Usd());
+        var m3 = new MoneyValue(1m, new Eur());
+
+        Assert.Equal(m1, m2);
+        Assert.NotEqual(m1, m3);
+    }
+
+    [Fact]
+    public void Addition_WithSameCurrency_ReturnsSum()
+    {
+        var total = new MoneyValue(5m, new Usd()) + new MoneyValue(3m, new Usd());
+        Assert.Equal(new MoneyValue(8m, new Usd()), total);
+    }
+
+    [Fact]
+    public void Addition_WithDifferentCurrency_Throws()
+    {
+        Assert.Throws<InvalidOperationException>(() =>
+            _ = new MoneyValue(5m, new Usd()) + new MoneyValue(1m, new Eur()));
+    }
+}

--- a/shared/Types.Test/Types.Test.csproj
+++ b/shared/Types.Test/Types.Test.csproj
@@ -1,0 +1,24 @@
+﻿<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <TargetFramework>net9.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.12.0" />
+    <PackageReference Include="xunit" Version="2.9.2" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.8.2" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="../Types/Types.csproj" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <Using Include="Xunit" />
+  </ItemGroup>
+
+</Project>

--- a/shared/Types/Money/Currencies.cs
+++ b/shared/Types/Money/Currencies.cs
@@ -1,0 +1,7 @@
+namespace Types.Money;
+
+/// <summary>US Dollar currency.</summary>
+public sealed record Usd() : Currency("USD", CurrencyType.FiatCurrency);
+
+/// <summary>Euro currency.</summary>
+public sealed record Eur() : Currency("EUR", CurrencyType.FiatCurrency);

--- a/shared/Types/Money/Currency.cs
+++ b/shared/Types/Money/Currency.cs
@@ -1,0 +1,35 @@
+namespace Types.Money;
+
+/// <summary>
+/// Describes broad categories of money.
+/// </summary>
+public enum CurrencyType
+{
+    FiatCurrency,
+    CommodityMoney,
+    DigitalFiatCurrency,
+    Cryptocurrency,
+    CBDC,
+    VirtualCurrency,
+    LocalCommunityCurrency,
+    RepresentativeMoney,
+    Stablecoins,
+}
+
+public interface ICurrency
+{
+    /// <summary>
+    /// ISO code for the currency, e.g. "USD" or "EUR".
+    /// </summary>
+    string Code { get; }
+
+    /// <summary>
+    /// Broad type describing the nature of this currency.
+    /// </summary>
+    CurrencyType CurrencyType { get; }
+}
+
+/// <summary>
+/// Base class for concrete currencies implementing <see cref="ICurrency"/>.
+/// </summary>
+public abstract record Currency(string Code, CurrencyType CurrencyType) : ICurrency;

--- a/shared/Types/Money/Money.cs
+++ b/shared/Types/Money/Money.cs
@@ -1,0 +1,28 @@
+using System;
+namespace Types.Money
+{
+    public readonly record struct Money(decimal Amount, Currency Currency)
+    {
+        public static Money operator +(Money left, Money right)
+        {
+            if (left.Currency != right.Currency)
+                throw new InvalidOperationException("Cannot add money with different currencies.");
+            return new(left.Amount + right.Amount, left.Currency);
+        }
+
+        public static Money operator -(Money left, Money right)
+        {
+            if (left.Currency != right.Currency)
+                throw new InvalidOperationException("Cannot subtract money with different currencies.");
+            return new(left.Amount - right.Amount, left.Currency);
+        }
+
+        public static Money operator *(Money money, decimal multiplier)
+            => new(money.Amount * multiplier, money.Currency);
+
+        public static Money operator *(decimal multiplier, Money money)
+            => money * multiplier;
+
+        public override string ToString() => $"{Amount} {Currency}";
+    }
+}

--- a/shared/Types/Types.sln
+++ b/shared/Types/Types.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types", "Types.csproj", "{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Types.Test", "..\Types.Test\Types.Test.csproj", "{419491C6-1480-4865-B9EA-0B220FDD6D96}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -27,6 +29,18 @@ Global
 		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x64.Build.0 = Release|Any CPU
 		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x86.ActiveCfg = Release|Any CPU
 		{8F3A9BE9-EFEE-4096-9108-B7466AED1FE1}.Release|x86.Build.0 = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|x64.ActiveCfg = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|x64.Build.0 = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|x86.ActiveCfg = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Debug|x86.Build.0 = Debug|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|Any CPU.Build.0 = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|x64.ActiveCfg = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|x64.Build.0 = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|x86.ActiveCfg = Release|Any CPU
+		{419491C6-1480-4865-B9EA-0B220FDD6D96}.Release|x86.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
## Summary
- create `ICurrency` interface to define currency contract
- add abstract `Currency` record and two concrete currencies
- update `Money` to use `Currency`
- adjust tests for new currency types
- move currency files into **Money** folder and mirror layout in tests

## Testing
- `dotnet test shared/Types/Types.sln -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_6865cf9e22188324a947aa545ea7259c