### PR TITLE
Remove docker-compose from Postgres resources

### DIFF
--- a/PostgreSql/README.md
+++ b/PostgreSql/README.md
@@ -1,0 +1,5 @@
+# PostgreSql Project
+
+This project contains all resources related to the PostgreSQL database used across other services. It holds:
+
+- **migrations** – SQL scripts for initializing and evolving the database schema.

--- a/PostgreSql/migrations/README.md
+++ b/PostgreSql/migrations/README.md
@@ -1,0 +1,2 @@
+This directory stores SQL migration files executed when the PostgreSQL container starts.
+Place initialization scripts such as table creation statements here.

--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ This repository demonstrates a very small layered setup using .NET 9.0. The root
   /Application
   /Shared
   /Client
+  /PostgreSql
 ```
 
 `WebApi` exposes the HTTP API and references the `Application`, `Infrastructure`, `Domain` and `Shared` libraries. Each of the library folders contains its own `.sln` file along with a matching `*.Test` project for unit tests.


### PR DESCRIPTION
## Summary
- clean up the new `PostgreSql` folder
- remove docker-compose file and install script
- simplify `PostgreSql/README.md`

## Testing
- `dotnet test Application/Application.sln --no-build`
- `dotnet test Domain/Domain.sln --no-build`
- `dotnet test Infrastructure/Infrastructure.sln --no-build`
- `dotnet test Shared/Shared.sln --no-build`
- `dotnet test WebApi/WebApi.sln --no-build`


------
https://chatgpt.com/codex/tasks/task_e_68699049c2588324add8b787141c71c6