### PR TITLE
Add Swagger to WebApi

### DIFF
--- a/WebApi/Program.cs
+++ b/WebApi/Program.cs
@@ -9,10 +9,14 @@ try
     builder.Host.UseNLog();
 
     // Add services to the container.
+    builder.Services.AddEndpointsApiExplorer();
+    builder.Services.AddSwaggerGen();
 
     var app = builder.Build();
 
     // Configure the HTTP request pipeline.
+    app.UseSwagger();
+    app.UseSwaggerUI();
 
     var summaries = new[]
     {

--- a/WebApi/WebApi.csproj
+++ b/WebApi/WebApi.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="NLog" Version="6.0.1" />
     <PackageReference Include="NLog.Web.AspNetCore" Version="6.0.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="6.5.0" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
## Summary
- integrate `Swashbuckle.AspNetCore`
- enable API explorer and Swagger

## Testing
- `dotnet build WebApi/WebApi.csproj -c Release`
- `dotnet test WebApi/WebApi.Test/WebApi.Test.csproj -v minimal`


------
https://chatgpt.com/codex/tasks/task_e_686c760dbaf8832485d5764cfdc29e15