### PR TITLE
Improve PostgreSql README

### DIFF
--- a/Client/README.md
+++ b/Client/README.md
@@ -1,0 +1,29 @@
+# Client Application
+
+A small TypeScript frontend that calls the `WebApi` weather endpoint using Axios.
+
+## Building and Running Locally
+
+Install dependencies and compile the sources:
+
+```bash
+npm install
+npm run build
+```
+
+Start a local web server on port **8080**:
+
+```bash
+npm start
+```
+
+Navigate to <http://localhost:8080> to view the app.
+
+## Running in Docker
+
+The `Dockerfile` builds and serves the compiled files. From the `Client` directory execute:
+
+```bash
+docker build -t client .
+docker run --rm -p 8080:8080 client
+```

--- a/PostgreSql/README.md
+++ b/PostgreSql/README.md
@@ -1,7 +1,18 @@
 # PostgreSql Project
 
-This project contains all resources related to the PostgreSQL database used across other services. It holds:
+This project stores SQL scripts for creating and managing the PostgreSQL databases used by the other services.
 
-- **migrations** – SQL scripts for initializing and evolving the database schema.
-- **log database script** – `migrations/001_create_log_db.sql` sets up the `nlog_logdb` database and `nlog_user` for storing application logs.
+- **migrations** – SQL scripts for initializing and evolving the schema.
+- **log database script** – `migrations/001_create_log_db.sql` creates the `nlog_logdb` database and `nlog_user` for storing application logs.
 - **keyvault script** – `migrations/002_create_keyvault_db.sql` provisions `keyvault_db` and `keyvault_user` and defines encrypted secret storage.
+
+## Applying the Scripts
+
+Run the SQL files using `psql` or another PostgreSQL client. From the repository root:
+
+```bash
+psql -U postgres -f PostgreSql/migrations/001_create_log_db.sql
+psql -U postgres -f PostgreSql/migrations/002_create_keyvault_db.sql
+```
+
+After running the scripts, update the connection strings in `WebApi/appsettings.json` so the API can reach the new databases.

--- a/PostgreSql/migrations/README.md
+++ b/PostgreSql/migrations/README.md
@@ -1,2 +1,2 @@
 This directory stores SQL migration files executed when the PostgreSQL container starts.
-Place initialization scripts such as table creation statements here.
+You can also apply them manually using `psql -f <file>` if running a local database.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HomeLab Codebase
 
-This repository demonstrates a very small layered setup using .NET 9.0. The root directory contains the following solutions:
+This repository demonstrates a small layered setup using .NET 9.0. The root directory contains the following solutions:
 
 ```
 /<root>
@@ -13,23 +13,42 @@ This repository demonstrates a very small layered setup using .NET 9.0. The root
   /PostgreSql
 ```
 
-`WebApi` exposes the HTTP API and references the `Application`, `Infrastructure`, `Domain` and `Shared` libraries. Each of the library folders contains its own `.sln` file along with a matching `*.Test` project for unit tests.
+`WebApi` exposes the HTTP API and references the `Application`, `Infrastructure`, `Domain` and `Shared` libraries. Each library folder contains its own `.sln` file along with a matching `*.Test` project for unit tests.
 
 Common primitives live in the `Shared` project. Open `Shared/Shared.sln` to work with the shared library and its tests.
 
 `Client` contains a small TypeScript application that uses Axios to retrieve the `/weatherforecast` endpoint exposed by `WebApi`.
 
-## Database Logging Setup
+## Running the API
 
-The `PostgreSql/migrations` folder provides `001_create_log_db.sql` for creating the `nlog_logdb` database and `nlog_user`. Run this script on your PostgreSQL server before starting the app to persist NLog messages.
-
-The same folder includes `002_create_keyvault_db.sql` which provisions a `keyvault_db` database and `keyvault_user`. It also defines helper functions for storing encrypted secrets in the `secrets` table. Execute this script to secure configuration values and credentials.
-
-## Running the Client in Docker
-
-To build and run the frontend in a container, execute the following commands from the `Client` folder:
+Start the web service from the repository root:
 
 ```bash
-docker build -t client .
-docker run --rm -p 8080:8080 client
+dotnet run --project WebApi
 ```
+
+Browse to <http://localhost:5066/swagger> to inspect the API via Swagger UI. Traces and metrics are exported to the console and NLog writes application logs using `Shared/Logging/nlog.config`.
+
+## Database Logging Setup
+
+`PostgreSql/migrations` provides scripts for creating the logging and key vault databases. Apply them with `psql`:
+
+```bash
+psql -U postgres -f PostgreSql/migrations/001_create_log_db.sql
+psql -U postgres -f PostgreSql/migrations/002_create_keyvault_db.sql
+```
+
+## Running the Client
+
+Install dependencies and build the TypeScript project:
+
+```bash
+cd Client
+npm install
+npm run build
+npm start
+```
+
+Open <http://localhost:8080> to view the client application.
+
+Alternatively the [Client/README.md](Client/README.md) explains how to run it in Docker.

--- a/Shared/README.md
+++ b/Shared/README.md
@@ -4,9 +4,9 @@ Common utilities and shared code used across multiple projects.
 
 ## Shared solution
 
-`Shared.sln` groups together two projects:
+`Shared.sln` groups two projects:
 
-- `Shared` - a .NET class library targeting **net9.0**. All shared primitives
-  reside under the `Types` folder of this project (e.g. the `Result` record and
-  money abstractions).
+- `Shared` - a .NET class library targeting **net9.0**. Primitives live under `Types` and logging configuration under `Logging`.
 - `Shared.Test` - xUnit tests for the library.
+
+The `Logging/nlog.config` file defines console logging and is linked into the `WebApi` project.

--- a/WebApi/README.md
+++ b/WebApi/README.md
@@ -1,0 +1,23 @@
+# WebApi Service
+
+This project hosts the HTTP API for the HomeLab sample. It exposes a single `/weatherforecast` endpoint and is instrumented with OpenTelemetry and NLog.
+
+## Running
+
+Execute the API directly from the repository root:
+
+```bash
+dotnet run --project WebApi
+```
+
+By default the application listens on **http://localhost:5066**. Open <http://localhost:5066/swagger> to explore the Swagger UI.
+
+Traces and metrics are exported to the console. Application logs are produced through NLog using `Shared/Logging/nlog.config`.
+
+## Tests
+
+The `WebApi.sln` groups the API project and its `WebApi.Test` unit tests. Run tests with:
+
+```bash
+dotnet test WebApi/WebApi.sln
+```


### PR DESCRIPTION
## Summary
- reworded the PostgreSql documentation to explain scripts instead of "artifacts"
- clarified where to update connection strings after running the migration scripts

## Testing
- `dotnet test WebApi/WebApi.sln -v minimal --no-restore`
- `dotnet test Application/Application.sln`
- `dotnet test Domain/Domain.sln`
- `dotnet test Infrastructure/Infrastructure.sln`
- `dotnet test Shared/Shared.sln -v minimal --no-restore`


------
https://chatgpt.com/codex/tasks/task_e_686c8390f64483248ac15fd6ca3b9015