### PR TITLE
Revise log migration tables

### DIFF
--- a/PostgreSql/README.md
+++ b/PostgreSql/README.md
@@ -3,7 +3,7 @@
 This project stores SQL scripts for creating and managing the PostgreSQL databases used by the other services.
 
 - **migrations** – SQL scripts for initializing and evolving the schema.
-- **log database script** – `migrations/001_create_log_db.sql` creates the `nlog_logdb` database and `nlog_user` for storing application logs.
+- **log database script** – `migrations/001_create_log_db.sql` provisions `logdb` and `startup_logdb` along with a `log_user` account. Each database contains a `providers` table and per-level tables named `traces`, `debugs`, `infos`, `warnings`, `errors`, and `fatals`.
 - **keyvault script** – `migrations/002_create_keyvault_db.sql` provisions `keyvault_db` and `keyvault_user` and defines encrypted secret storage.
 
 ## Applying the Scripts

--- a/PostgreSql/migrations/001_create_log_db.sql
+++ b/PostgreSql/migrations/001_create_log_db.sql
@@ -1,26 +1,143 @@
--- Creates a database and user for NLog to store log entries.
+-- Creates general purpose log databases and a dedicated user.
 -- Adjust the password before executing in production environments.
 
 -- Create dedicated user
-CREATE USER nlog_user WITH PASSWORD 'ChangeMe';
+CREATE USER log_user WITH PASSWORD 'ChangeMe';
 
--- Create separate database for logs
-CREATE DATABASE nlog_logdb;
+-- Databases for runtime and startup logs
+CREATE DATABASE logdb;
+CREATE DATABASE startup_logdb;
 
--- Grant privileges on the new database to the logging user
-GRANT ALL PRIVILEGES ON DATABASE nlog_logdb TO nlog_user;
+GRANT ALL PRIVILEGES ON DATABASE logdb TO log_user;
+GRANT ALL PRIVILEGES ON DATABASE startup_logdb TO log_user;
 
-\c nlog_logdb
+\c logdb
 
--- Table storing log entries written by NLog
-CREATE TABLE IF NOT EXISTS log (
+-- Store log providers
+CREATE TABLE IF NOT EXISTS providers (
     id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+
+-- Log tables by level
+CREATE TABLE IF NOT EXISTS traces (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
     logged TIMESTAMPTZ NOT NULL,
-    level VARCHAR(50),
     logger VARCHAR(250),
     message TEXT,
     exception TEXT
 );
 
--- Allow the logging user to operate on the log table
-GRANT ALL PRIVILEGES ON TABLE log TO nlog_user;
+CREATE TABLE IF NOT EXISTS debugs (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS infos (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS warnings (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS errors (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS fatals (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO log_user;
+
+--
+-- Startup log database
+--
+\c startup_logdb
+
+CREATE TABLE IF NOT EXISTS providers (
+    id SERIAL PRIMARY KEY,
+    name TEXT UNIQUE NOT NULL
+);
+
+CREATE TABLE IF NOT EXISTS traces (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS debugs (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS infos (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS warnings (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS errors (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+CREATE TABLE IF NOT EXISTS fatals (
+    id SERIAL PRIMARY KEY,
+    provider_id INT REFERENCES providers(id),
+    logged TIMESTAMPTZ NOT NULL,
+    logger VARCHAR(250),
+    message TEXT,
+    exception TEXT
+);
+
+GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO log_user;


### PR DESCRIPTION
## Summary
- create log tables for Trace, Debug, Info, Warning, Error and Fatal
- document the per-level log tables in README
- rename log tables without prefix and use plural names

## Testing
- `dotnet test Domain/Domain.sln --no-build --verbosity normal`
- `dotnet test WebApi/WebApi.sln --no-build --verbosity minimal`
- `dotnet test Application/Application.sln --no-build --verbosity minimal`
- `dotnet test Shared/Shared.sln --no-build --verbosity minimal`
- `dotnet test Infrastructure/Infrastructure.sln --no-build --verbosity minimal`

------
https://chatgpt.com/codex/tasks/task_e_68729aadb1d4832489b7764cdd1aecfc