### PR TITLE
Add Dockerfile for WebApi service

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+.git
+**/bin/
+**/obj/
+Client/node_modules/
+.DS_Store

--- a/README.md
+++ b/README.md
@@ -29,6 +29,17 @@ dotnet run --project WebApi
 
 Browse to <http://localhost:5066/swagger> to inspect the API via Swagger UI. Traces and metrics are exported to the console and NLog writes application logs using `Shared/Logging/nlog.config`.
 
+### Docker
+
+Build and run the API in a container from the repository root:
+
+```bash
+docker build -f WebApi/Dockerfile -t homelab-api .
+docker run -p 8080:8080 homelab-api
+```
+
+The application listens on port **8080** inside the container.
+
 ## Database Logging Setup
 
 `PostgreSql/migrations` provides scripts for creating the logging and key vault databases. Apply them with `psql`:

--- a/WebApi/Dockerfile
+++ b/WebApi/Dockerfile
@@ -1,0 +1,26 @@
+# Build stage
+FROM mcr.microsoft.com/dotnet/sdk:9.0 AS build
+WORKDIR /src
+
+# copy csproj files and restore
+COPY WebApi/WebApi.csproj WebApi/
+COPY Application/Application.csproj Application/
+COPY Infrastructure/Infrastructure.csproj Infrastructure/
+COPY Domain/Domain.csproj Domain/
+COPY Shared/Shared/Shared.csproj Shared/Shared/
+
+RUN dotnet restore WebApi/WebApi.csproj
+
+# copy the rest of the repo
+COPY . .
+
+RUN dotnet publish WebApi/WebApi.csproj -c Release -o /app/publish /p:UseAppHost=false
+
+# runtime image
+FROM mcr.microsoft.com/dotnet/aspnet:9.0 AS final
+WORKDIR /app
+COPY --from=build /app/publish .
+
+ENV ASPNETCORE_URLS=http://+:8080
+EXPOSE 8080
+ENTRYPOINT ["dotnet", "WebApi.dll"]

--- a/WebApi/README.md
+++ b/WebApi/README.md
@@ -14,6 +14,17 @@ By default the application listens on **http://localhost:5066**. Open <http://lo
 
 Traces and metrics are exported to the console. Application logs are produced through NLog using `Shared/Logging/nlog.config`.
 
+## Docker
+
+You can also run the API in a container:
+
+```bash
+docker build -f WebApi/Dockerfile -t homelab-api .
+docker run -p 8080:8080 homelab-api
+```
+
+The service listens on port **8080** inside the container.
+
 ## Tests
 
 The `WebApi.sln` groups the API project and its `WebApi.Test` unit tests. Run tests with:


### PR DESCRIPTION
## Summary
- add `.dockerignore` to reduce Docker build context
- add `WebApi/Dockerfile` with multi-stage build
- document container usage in `README.md` and `WebApi/README.md`

## Testing
- `dotnet --version`
- *No tests run due to missing .NET 9.0 SDK*


------
https://chatgpt.com/codex/tasks/task_e_6872c18d21308324894fcabf127b897b