### PR TITLE
Add Dockerfile for Svelte client

### DIFF
--- a/Client/Dockerfile
+++ b/Client/Dockerfile
@@ -1,0 +1,14 @@
+# Build stage
+FROM node:20-alpine AS build
+WORKDIR /app
+COPY package*.json ./
+RUN npm ci
+COPY . .
+RUN npm run build
+
+# Runtime stage
+FROM node:20-alpine AS runtime
+WORKDIR /app
+COPY --from=build /app .
+EXPOSE 4173
+CMD ["npm", "run", "preview", "--", "--host", "0.0.0.0", "--port", "4173"]

--- a/Client/README.md
+++ b/Client/README.md
@@ -22,3 +22,14 @@ Create an optimized production build and preview it locally:
 npm run build
 npm run preview
 ```
+
+## Running with Docker
+
+Build the container image and start the app using Docker:
+
+```bash
+docker build -t homelab-client .
+docker run -p 4173:4173 homelab-client
+```
+
+Navigate to <http://localhost:4173> to view the application.


### PR DESCRIPTION
## Summary
- add Dockerfile to build and serve the SvelteKit client
- document Docker usage in Client README
- install build dependencies for Node packages
- remove build dependency install from Dockerfile

## Testing
- `dotnet test WebApi/WebApi.sln`


------
https://chatgpt.com/codex/tasks/task_e_6872c1807780832495bf596169d539d4