### PR TITLE
Fix documentation paths and clarify project list

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # HomeLab Codebase
 
-This repository demonstrates a small layered setup using .NET 9.0. The root directory contains the following solutions:
+This repository demonstrates a small layered setup using .NET 9.0. The root directory contains the following projects:
 
 ```
 /<root>
@@ -13,11 +13,11 @@ This repository demonstrates a small layered setup using .NET 9.0. The root dire
   /PostgreSql
 ```
 
-`WebApi` exposes the HTTP API and references the `Application`, `Infrastructure`, `Domain` and `Shared` libraries. Each library folder contains its own `.sln` file along with a matching `*.Test` project for unit tests.
+`WebApi` exposes the HTTP API and references the `Application`, `Infrastructure`, `Domain` and `Shared` libraries. Each of these library folders contains its own `.sln` file along with a matching `*.Test` project for unit tests.
 
 Common primitives live in the `Shared` project. Open `Shared/Shared.sln` to work with the shared library and its tests.
 
-`Client` hosts a SvelteKit front end that can interact with the API exposed by `WebApi`.
+`Client` hosts a SvelteKit front end, and `PostgreSql` holds SQL migration scripts.
 
 ## Running the API
 
@@ -27,7 +27,7 @@ Start the web service from the repository root:
 dotnet run --project WebApi
 ```
 
-Browse to <http://localhost:5066/swagger> to inspect the API via Swagger UI. Traces and metrics are exported to the console and NLog writes application logs using `Shared/Logging/nlog.config`.
+Browse to <http://localhost:5066/swagger> to inspect the API via Swagger UI. Traces and metrics are exported to the console and NLog writes application logs using `Shared/Shared/Logging/nlog.config`.
 
 ### Docker
 

--- a/WebApi/README.md
+++ b/WebApi/README.md
@@ -12,7 +12,7 @@ dotnet run --project WebApi
 
 By default the application listens on **http://localhost:5066**. Open <http://localhost:5066/swagger> to explore the Swagger UI.
 
-Traces and metrics are exported to the console. Application logs are produced through NLog using `Shared/Logging/nlog.config`.
+Traces and metrics are exported to the console. Application logs are produced through NLog using `Shared/Shared/Logging/nlog.config`.
 
 ## Docker
 


### PR DESCRIPTION
## Summary
- update project listing in root README
- correct NLog config path in documentation

## Testing
- `dotnet test WebApi/WebApi.sln -v n`
- `dotnet test Domain/Domain.sln -v n`
- `dotnet test Application/Application.sln -v n`
- `dotnet test Infrastructure/Infrastructure.sln -v n`
- `dotnet test Shared/Shared.sln -v n`


------
https://chatgpt.com/codex/tasks/task_e_6872d2cf19108324af818faa0df391b6